### PR TITLE
Added spigot repository to pom.xml

### DIFF
--- a/MentionBeep/pom.xml
+++ b/MentionBeep/pom.xml
@@ -13,6 +13,12 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
+  <repositories>
+    <repository>
+      <id>spigot</id>
+      <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>


### PR DESCRIPTION
Adding the spigot repo to pom.xml lets maven automatically grab spigot dependency when building.